### PR TITLE
add handling for numbers 1194649, 12327121 that cause infinite loop i…

### DIFF
--- a/baillie_psw.py
+++ b/baillie_psw.py
@@ -24,6 +24,11 @@ def baillie_psw(candidate):
     if not miller_rabin_base_2(candidate):
         return False
 
+    # These two composite numbers are Miller-Rabin pseudoprimes and cause
+    # an infinite loop in the below implementation of the Lucas Test
+    if candidate in set([1194649, 12327121]):
+        return False
+
     # Finally perform the Lucas primality test
     D = D_chooser(candidate)
     if not lucas_pp(candidate, D, 1, (1-D)/4):


### PR DESCRIPTION
I love this module.  Thank you for making it.

I found two miller-rabin pseudoprimes that seem to cause an infinite loop in the Lucas test
1194649 and 12327121
Luckily they are composites.
http://www.isprimenumber.com/prime/1194649
http://www.isprimenumber.com/prime/12327121

You can seem them fail in the current module by running
from baillie_psw_master import baillie_psw
print baillie_psw.baillie_psw(1194649)
print baillie_psw.baillie_psw(12327121)

I do not know enough about the Lucas test to debug it, but this pull request gives a workaround until a fix could be found.  

Cheers